### PR TITLE
Stop panic on invalid top response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.1.2 - 2019-02-04
+## 1.1.2 - 2019-02-12
 ### Fixed 
 - Don't panic on invalid mongo top response
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.2 - 2019-02-04
+### Fixed 
+- Don't panic on invalid mongo top response
+
 ## 1.1.1 - 2019-02-04
 ### Fixed 
 - Use correct protocol version

--- a/src/entities/collect.go
+++ b/src/entities/collect.go
@@ -173,6 +173,10 @@ func collectTop(c Collector) error {
 
 	for key, collectionStats := range topMetrics.Totals {
 		splitKey := strings.SplitN(key, ".", 2)
+		if len(splitKey) != 2 {
+			log.Error("The output of the top command contained unexpected key %s which is not of the form <database>.<collection>", key)
+			continue
+		}
 		databaseName := splitKey[0]
 		collectionName := splitKey[1]
 

--- a/src/mongodb.go
+++ b/src/mongodb.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mongodb"
-	integrationVersion = "1.1.1"
+	integrationVersion = "1.1.2"
 )
 
 var (

--- a/src/test/fake_session.go
+++ b/src/test/fake_session.go
@@ -112,6 +112,20 @@ func unmarshalCommand(cmd string, result interface{}) error {
 						"count": 1,
 					},
 				},
+				"testnocollect": map[string]interface{}{
+					"total": map[string]interface{}{
+						"time":  305277,
+						"count": 2825,
+					},
+					"readLock": map[string]interface{}{
+						"time":  305123,
+						"count": 2893,
+					},
+					"writeLock": map[string]interface{}{
+						"time":  13,
+						"count": 1,
+					},
+				},
 			},
 		})
 		return bson.Unmarshal(marshalled, result)


### PR DESCRIPTION
#### Description of the changes

Skip entries in mongo top command output if they are not of the form `<database>.<collection>` because they don't match the documented format and I'm unable to get more information about what they could be. 

Fixes #34 

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
