### PR TITLE
Add no_database_sample flag

### DIFF
--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -26,6 +26,7 @@ type ArgumentList struct {
 	Passphrase            string `default:"" help:"Passphrase for decrypting Private Key"`
 	SslInsecureSkipVerify bool   `default:"false" help:"Skip verification of the certificate sent by the host. This can make the connection susceptible to man-in-the-middle attacks, and should only be used for testing."`
 	Filters               string `default:"" help:"JSON data defining database and collection filters."`
+	NoDatabaseSample      bool   `default:"false" help:"Skip MongoDatabaseSample, so won't run ListDatabases command."`
 	ConcurrentCollections int    `default:"50" help:"The number of entities to collect metrics for concurrently. This is tunable to reduce CPU and memory requirements."`
 	ShowVersion           bool   `default:"false" help:"Print build information and exit"`
 }
@@ -44,6 +45,11 @@ func (args *ArgumentList) Validate() error {
 		}
 		args.MongodbClusterName = args.ClusterName
 		log.Warn("Using the deprecated config ClusterName instead of MongodbClusterName")
+	}
+
+	if args.NoDatabaseSample && len(args.Filters) > 0 {
+		log.Warn("Ignoring filters because no_database_sample was selected")
+		args.Filters = ""
 	}
 
 	if _, err := strconv.Atoi(args.Port); err != nil {

--- a/src/mongodb.go
+++ b/src/mongodb.go
@@ -82,7 +82,7 @@ func main() {
 	entities.ClusterName = args.MongodbClusterName
 
 	// Feed the worker pool with entities to be collected
-	go FeedWorkerPool(session, collectorChan, mongoIntegration)
+	go FeedWorkerPool(session, collectorChan, mongoIntegration, args.NoDatabaseSample)
 
 	// Wait for workers to finish
 	wg.Wait()

--- a/src/workers.go
+++ b/src/workers.go
@@ -60,7 +60,7 @@ func collectorWorker(collectorChan chan entities.Collector, wg *sync.WaitGroup) 
 }
 
 // FeedWorkerPool feeds the workers with the collectors that contain the info needed to collect each entity
-func FeedWorkerPool(session connection.Session, collectorChan chan entities.Collector, integration *integration.Integration) {
+func FeedWorkerPool(session connection.Session, collectorChan chan entities.Collector, integration *integration.Integration, noDbSample bool) {
 	defer close(collectorChan)
 
 	// Create a wait group for each of the get*Collectors calls
@@ -95,8 +95,10 @@ func FeedWorkerPool(session connection.Session, collectorChan chan entities.Coll
 		go createShardCollectors(getWg, session, collectorChan, integration)
 	}
 
-	getWg.Add(1)
-	go createDatabaseCollectors(getWg, session, collectorChan, integration)
+	if !noDbSample {
+		getWg.Add(1)
+		go createDatabaseCollectors(getWg, session, collectorChan, integration)
+	}
 
 	getWg.Wait()
 }


### PR DESCRIPTION
This flag is needed for the OHI to work on older databases with too many collections.  On these, the mongo **listDatabases()** command used in the OHI requires too many resources to run on the mongo host.

When enabled, this flag will skip creating `MongoDatabaseSample` and `MongoCollectionSample`
We have tested the functionality on a small Mongo cluster, and it works fine.