### PR TITLE
Mongodb-Logging-Template

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -49,6 +49,8 @@ nfpms:
     contents:
       - src: "mongodb-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/mongodb-config.yml.sample"
+      - src: "mongodb-log.yml.example"
+        dst: "/etc/newrelic-infra/logging.d/mongodb-log.yml.example"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-mongodb/CHANGELOG.md"
       - src: "README.md"

--- a/mongodb-log.yml.example
+++ b/mongodb-log.yml.example
@@ -1,0 +1,7 @@
+logs:
+# This sample file will forward mongodb error logs to NR once it's renamed to mongodb-log.yml
+# On Linux systems no restart is needed
+  - name: "mongodblog"
+    file: /var/log/mongodb/mongodb.log
+    attributes:
+      logtype: mongodb

--- a/mongodb-log.yml.example
+++ b/mongodb-log.yml.example
@@ -1,6 +1,11 @@
+###############################################################################
+# This sample file will forward mongodb error logs to NR once                 #
+#   it is renamed to mongodb-log.yml                                          #
+# On Linux systems no restart is needed after it is renamed                   #
+# Source: mongodb error log file                                              #
+# Available customization parameters: attributes, max_line_kb, pattern        #
+###############################################################################
 logs:
-# This sample file will forward mongodb error logs to NR once it's renamed to mongodb-log.yml
-# On Linux systems no restart is needed
   - name: "mongodblog"
     file: /var/log/mongodb/mongodb.log
     attributes:


### PR DESCRIPTION
Created a default Mongodb logging template. This will allow customers to easily send Mongodb logs to NR by simply renaming the .example file to .yml.