### PR TITLE
NR-145611: add release toolkit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>newrelic/coreint-automation:renovate-base.json5"
+  ]
+}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -108,13 +108,6 @@ jobs:
           GPG_MAIL: 'infrastructure-eng@newrelic.com'
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-      - name: Notify failure via Slack
-        if: ${{ failure() }}
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
       - name: Test package installability
         uses: newrelic/integrations-pkg-test-action/linux@v1
         with:
@@ -165,13 +158,6 @@ jobs:
         shell: bash
         run: |
           build/windows/upload_msi.sh ${INTEGRATION} ${{ matrix.goarch }} ${TAG}
-      - name: Notify failure via Slack
-        if: ${{ failure() }}
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
 
   publish-to-s3:
     name: Send release assets to S3
@@ -216,3 +202,15 @@ jobs:
           packageLocation: repo
           stagingRepo: true
           upgrade: false
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [ test-nix, test-windows, prerelease, package-win, publish-to-s3 ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -1,10 +1,11 @@
-name: Push/PR pipeline
+name: Push/PR
 
 on:
   push:
     branches:
       - main
       - master
+      - renovate/**
   pull_request:
 
 env:
@@ -28,6 +29,8 @@ jobs:
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1
 
   snyk:
     name: Run security checks via snyk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release pipeline
+name: Create release artifacts
 
 on:
   release:
@@ -58,3 +58,15 @@ jobs:
           integration: 'nri-${{ env.INTEGRATION }}' # Required, with nri- prefix
           packageLocation: repo
           upgrade: false
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [ publish-to-s3 ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [release pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,51 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - renovate/**
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  trivy:
+    name: Trivy security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.11.2
+        if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'build'
+          # test private key
+          skip-files: 'tests/integration/tls_cert/redis.key'
+
+      - name: Run Trivy vulnerability scanner sarif output
+        uses: aquasecurity/trivy-action@0.11.2
+        if: ${{ github.event.schedule }} # Generate sarif when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          skip-dirs: 'build'
+          # test private key
+          skip-files: 'tests/integration/tls_cert/redis.key'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ github.event.schedule }} # Upload sarif when running periodically
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trigger_prerelease.yml
+++ b/.github/workflows/trigger_prerelease.yml
@@ -1,0 +1,20 @@
+name: Trigger prerelease creation
+
+# This workflow triggers a prerelease creation with changelog and the release notes created by the release toolkit.
+# This workflow should be triggered merely from the default branch.
+# If you wish to be 100% free creating a prerelease, just create it manually.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 7 * * 1"
+
+jobs:
+  prerelease:
+    uses: newrelic/coreint-automation/.github/workflows/trigger_prerelease.yaml@v1
+    secrets:
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel:  ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
+    with:
+      rt-included-files: go.mod,go.sum,build/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ dist/
 # build files
 src/versioninfo.json
 src/resource.syso
+
+# Release toolkit
+CHANGELOG.partial.md
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
+
+## Unreleased
+
 ## 2.8.0 (2023-06-06)
-# Changed
+### Changed
 - Update Go version to 1.20
 
 ## 2.7.2  (2022-06-28)

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,15 @@ integration-test:
 	@docker-compose -f tests/integration/docker-compose.yml up -d --build
 	@go test -v -tags=integration ./tests/integration/. ; (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
 
+# rt-update-changelog runs the release-toolkit run.sh script by piping it into bash to update the CHANGELOG.md.
+# It also passes down to the script all the flags added to the make target. To check all the accepted flags,
+# see: https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh
+#  e.g. `make rt-update-changelog -- -v`
+rt-update-changelog:
+	curl "https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/run.sh" | bash -s -- $(filter-out $@,$(MAKECMDGOALS))
+
 # Include thematic Makefiles
 include $(CURDIR)/build/ci.mk
 include $(CURDIR)/build/release.mk
 
-.PHONY: all build clean compile test
+.PHONY: all build clean compile test rt-update-changelog

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.20.6-bookworm
 
 ARG GH_VERSION='1.9.2'
 

--- a/go.sum
+++ b/go.sum
@@ -16,14 +16,11 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
-github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster as builder
+FROM golang:1.20.6-bookworm as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-mongodb
 COPY . .


### PR DESCRIPTION
- [x] The branch of the PR is prefixed with renovate/*
- [x] Tests pass in renovate branches
- [x] security workflow is included and will pass in renovate branches
- [x] the changelog is validated in push_pr workflow
- [x] The repository has the secrets available
- [x] Release schedule is documented and not colliding
- [x] rt-update-changelog is in Makefile
- [x] Tags with leading v are safe
- [x] Common renovate config is pointed
- [x] Potential troublesome dependencies are checked
- [x] pre-release and release workflows are updated to notify failures
- [x] CHANGELOG.partial.md is in .gitignore
- [x] release-toolkit action excluded/included fields are set
- [x] Docker image pins go patch version
- [ ] The dependency dashboard is sanitized --> It will be enabled when the PR is merged, and then we need to remove Worktato comment and set `dependencies` label.