### PR TITLE
docs: update changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ### ⛓️ Dependencies
 - Updated golang version to v1.24.4
 
-## v2.10.0 - 2025-02-04
-
 ### 🚀 Enhancements
 - Add FIPS compliant packages
 


### PR DESCRIPTION
fips compliant packages were released as part of this new version release - https://github.com/newrelic/nri-mongodb/releases/tag/v2.9.3