### PR TITLE
docs: update changelog for go v1.25.8 security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### security
+- update go to v1.25.8
+
 ## v2.11.0 - 2026-02-10
 
 ### 🛡️ Security notices


### PR DESCRIPTION
## Changes
- Added `### security` section to `## Unreleased` in CHANGELOG.md
- go v1.25.8 upgrade fixes security vulnerabilities and should be categorized as a security fix
